### PR TITLE
Phoenix35 patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use an evergreen browser: [Mozilla Firefox](<https://www.mozilla.org/en-US/firef
 
 <p class="notice">DevDocs has not updated its JS info since 2018.</p> Use [MDN](<https://developer.mozilla.org/en-US/docs/Learn>) search functionality if you don't find something.
 
-Install [DevDocs desktop](<https://devdocs.egoist.moe/>) (by Egoist).  
+Install [DevDocs desktop](<https://github.com/egoist/devdocs-desktop/releases>) (by Egoist).  
 In "Preferences", enable following documentation
   - CSS
   - DOM

--- a/resources/index.md
+++ b/resources/index.md
@@ -5,7 +5,7 @@ description: A curated collection of resources to learn and stay up-to-date with
 
 ## Everyone
 
-- [DevDocs](<https://devdocs.io/>); also available as a [desktop app](<https://devdocs.egoist.moe/>).
+- [DevDocs](<https://devdocs.io/>); also available as a [desktop app](<https://github.com/egoist/devdocs-desktop/releases>).
 - [ESLint config](<https://github.com/Phoenix35/eslint-config>)
 
 ## Beginners


### PR DESCRIPTION
DevDocs desktop changed URL. The .moe domain died, migrated to github releases